### PR TITLE
Add support for general two-particle interactions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@ TODO list
 =========
 
 * Zero temperature calculations
-* Generic two particle interaction matrix
 * User-provided bath basis matrices
 * Imaginary time susceptibilities
 * Sector selection

--- a/example/3orbital2bath.py
+++ b/example/3orbital2bath.py
@@ -155,8 +155,15 @@ if MPI.COMM_WORLD.Get_rank() == 0:
 # energy splitting the shape would be (2, 2, 3, 3).
 solver.hloc[0, 0, 1, 1] = -0.6  # spin1 = spin2 = up and down, orb1 = orb2 = 1
 
-# Change Jp
-solver.Jp = 0.15
+# Change elements of the interaction matrix corresponding to Jp
+# The order of indices of solver.U is
+# orb1, spin1, orb2, spin2, orb3, spin3, orb4, spin4.
+Jp = 0.15
+for s, o1, o2 in product(range(2), orbs, orbs):
+    if o1 == o2:
+        continue
+    solver.U[o1, s, o1, 1 - s, o2, s, o2, 1 - s] = 0.5 * Jp
+    solver.U[o1, s, o1, 1 - s, o2, 1 - s, o2, s] = -0.5 * Jp
 
 # Update some bath parameters
 solver.bath.eps[0, 2, 1] = -0.4  # spin = up and down, orb1 = 2, nu = 1

--- a/tests/test_solver_general.py
+++ b/tests/test_solver_general.py
@@ -171,6 +171,33 @@ class TestEDIpackSolverBathGeneral(unittest.TestCase):
         return results
 
     @classmethod
+    def change_int_params(cls, U, new_int_params):
+        Uloc = new_int_params["Uloc"]
+        Ust = new_int_params["Ust"]
+        Jh = new_int_params["Jh"]
+        Jx = new_int_params["Jx"]
+        Jp = new_int_params["Jp"]
+        # Uloc
+        for s, o in product(range(2), cls.orbs):
+            U[o, s, o, 1 - s, o, s, o, 1 - s] = 0.5 * Uloc[o]
+            U[o, s, o, 1 - s, o, 1 - s, o, s] = -0.5 * Uloc[o]
+        for s, o1, o2 in product(range(2), cls.orbs, cls.orbs):
+            if o1 == o2:
+                continue
+            # Ust
+            U[o1, s, o2, 1 - s, o1, s, o2, 1 - s] = 0.5 * Ust
+            U[o1, s, o2, 1 - s, o2, 1 - s, o1, s] = -0.5 * Ust
+            # Ust - Jh
+            U[o1, s, o2, s, o1, s, o2, s] = 0.5 * (Ust - Jh)
+            U[o1, s, o2, s, o2, s, o1, s] = -0.5 * (Ust - Jh)
+            # Jx
+            U[o1, s, o2, 1 - s, o2, s, o1, 1 - s] = 0.5 * Jx
+            U[o1, s, o2, 1 - s, o1, 1 - s, o2, s] = -0.5 * Jx
+            # Jp
+            U[o1, s, o1, 1 - s, o2, s, o2, 1 - s] = 0.5 * Jp
+            U[o1, s, o1, 1 - s, o2, 1 - s, o2, s] = -0.5 * Jp
+
+    @classmethod
     def assert_all(cls, s, **refs):
         assert_allclose(s.densities, refs['densities'], atol=1e-8)
         assert_allclose(s.double_occ, refs['double_occ'], atol=1e-8)
@@ -251,11 +278,7 @@ class TestEDIpackSolverBathGeneral(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -382,11 +405,7 @@ class TestEDIpackSolverBathGeneral(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -518,11 +537,7 @@ class TestEDIpackSolverBathGeneral(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -654,11 +669,7 @@ class TestEDIpackSolverBathGeneral(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -798,11 +809,7 @@ class TestEDIpackSolverBathGeneral(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0

--- a/tests/test_solver_hybrid.py
+++ b/tests/test_solver_hybrid.py
@@ -168,6 +168,33 @@ class TestEDIpackSolverBathHybrid(unittest.TestCase):
         return results
 
     @classmethod
+    def change_int_params(cls, U, new_int_params):
+        Uloc = new_int_params["Uloc"]
+        Ust = new_int_params["Ust"]
+        Jh = new_int_params["Jh"]
+        Jx = new_int_params["Jx"]
+        Jp = new_int_params["Jp"]
+        # Uloc
+        for s, o in product(range(2), cls.orbs):
+            U[o, s, o, 1 - s, o, s, o, 1 - s] = 0.5 * Uloc[o]
+            U[o, s, o, 1 - s, o, 1 - s, o, s] = -0.5 * Uloc[o]
+        for s, o1, o2 in product(range(2), cls.orbs, cls.orbs):
+            if o1 == o2:
+                continue
+            # Ust
+            U[o1, s, o2, 1 - s, o1, s, o2, 1 - s] = 0.5 * Ust
+            U[o1, s, o2, 1 - s, o2, 1 - s, o1, s] = -0.5 * Ust
+            # Ust - Jh
+            U[o1, s, o2, s, o1, s, o2, s] = 0.5 * (Ust - Jh)
+            U[o1, s, o2, s, o2, s, o1, s] = -0.5 * (Ust - Jh)
+            # Jx
+            U[o1, s, o2, 1 - s, o2, s, o1, 1 - s] = 0.5 * Jx
+            U[o1, s, o2, 1 - s, o1, 1 - s, o2, s] = -0.5 * Jx
+            # Jp
+            U[o1, s, o1, 1 - s, o2, s, o2, 1 - s] = 0.5 * Jp
+            U[o1, s, o1, 1 - s, o2, 1 - s, o2, s] = -0.5 * Jp
+
+    @classmethod
     def assert_all(cls, s, **refs):
         assert_allclose(s.densities, refs['densities'], atol=1e-8)
         assert_allclose(s.double_occ, refs['double_occ'], atol=1e-8)
@@ -242,11 +269,7 @@ class TestEDIpackSolverBathHybrid(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -366,11 +389,7 @@ class TestEDIpackSolverBathHybrid(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -491,11 +510,7 @@ class TestEDIpackSolverBathHybrid(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -615,11 +630,7 @@ class TestEDIpackSolverBathHybrid(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -741,11 +752,7 @@ class TestEDIpackSolverBathHybrid(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0

--- a/tests/test_solver_normal.py
+++ b/tests/test_solver_normal.py
@@ -171,6 +171,33 @@ class TestEDIpackSolverBathNormal(unittest.TestCase):
         return results
 
     @classmethod
+    def change_int_params(cls, U, new_int_params):
+        Uloc = new_int_params["Uloc"]
+        Ust = new_int_params["Ust"]
+        Jh = new_int_params["Jh"]
+        Jx = new_int_params["Jx"]
+        Jp = new_int_params["Jp"]
+        # Uloc
+        for s, o in product(range(2), cls.orbs):
+            U[o, s, o, 1 - s, o, s, o, 1 - s] = 0.5 * Uloc[o]
+            U[o, s, o, 1 - s, o, 1 - s, o, s] = -0.5 * Uloc[o]
+        for s, o1, o2 in product(range(2), cls.orbs, cls.orbs):
+            if o1 == o2:
+                continue
+            # Ust
+            U[o1, s, o2, 1 - s, o1, s, o2, 1 - s] = 0.5 * Ust
+            U[o1, s, o2, 1 - s, o2, 1 - s, o1, s] = -0.5 * Ust
+            # Ust - Jh
+            U[o1, s, o2, s, o1, s, o2, s] = 0.5 * (Ust - Jh)
+            U[o1, s, o2, s, o2, s, o1, s] = -0.5 * (Ust - Jh)
+            # Jx
+            U[o1, s, o2, 1 - s, o2, s, o1, 1 - s] = 0.5 * Jx
+            U[o1, s, o2, 1 - s, o1, 1 - s, o2, s] = -0.5 * Jx
+            # Jp
+            U[o1, s, o1, 1 - s, o2, s, o2, 1 - s] = 0.5 * Jp
+            U[o1, s, o1, 1 - s, o2, 1 - s, o2, s] = -0.5 * Jp
+
+    @classmethod
     def assert_all(cls, s, **refs):
         assert_allclose(s.densities, refs['densities'], atol=1e-8)
         assert_allclose(s.double_occ, refs['double_occ'], atol=1e-8)
@@ -244,11 +271,7 @@ class TestEDIpackSolverBathNormal(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -368,11 +391,7 @@ class TestEDIpackSolverBathNormal(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -493,11 +512,7 @@ class TestEDIpackSolverBathNormal(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -617,11 +632,7 @@ class TestEDIpackSolverBathNormal(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0
@@ -744,11 +755,7 @@ class TestEDIpackSolverBathNormal(unittest.TestCase):
                           'Jh': 0.1,
                           'Jx': 0.2,
                           'Jp': 0.0}
-        solver.Uloc = new_int_params['Uloc']
-        solver.Ust = new_int_params['Ust']
-        solver.Jh = new_int_params['Jh']
-        solver.Jx = new_int_params['Jx']
-        solver.Jp = new_int_params['Jp']
+        self.change_int_params(solver.U, new_int_params)
         solver.comm.barrier()
 
         beta = 120.0


### PR DESCRIPTION
Public API change: Attributes `Uloc`, `Ust`, `Jh`, `Jx` and `Jp` of class `EDIpackSolver` have been removed and replaced with a single attribute `U` giving read/write access to the two-particle interaction tensor.