### PR TITLE
Port to TRIQS 4.0

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -35,4 +35,4 @@ requirements:
     - mpi4py
     - networkx
     - edipack::edipack>=6.0.0
-    - conda-forge::triqs>=3.2.0
+    - conda-forge::triqs>=4.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       env:
         CXX: g++
       run: |
-           git clone https://github.com/TRIQS/triqs --branch 3.3.x triqs.git
+           git clone https://github.com/TRIQS/triqs --branch 4.0.x triqs.git
            mkdir triqs.build && pushd triqs.build
            cmake ../triqs.git                                                  \
              -DCMAKE_BUILD_TYPE=Release                                        \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       shell: "bash -l {0}"
       run: |
            sudo apt-get update -q
-           sudo apt-get install -y gfortran libopenmpi-dev libboost-dev        \
+           sudo apt-get install -y gfortran g++-14 libopenmpi-dev libboost-dev \
                libblas-dev liblapack-dev libfftw3-dev libgmp-dev libhdf5-dev   \
                libscalapack-mpi-dev
 
@@ -93,7 +93,7 @@ jobs:
     - name: Build & install TRIQS
       shell: "bash -l {0}"
       env:
-        CXX: g++
+        CXX: g++-14
       run: |
            git clone https://github.com/TRIQS/triqs --branch 4.0.x triqs.git
            mkdir triqs.build && pushd triqs.build

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Dependencies
 * NetworkX
 * mpi4py
 * [edipack2py >= 6.0.0](https://github.com/EDIpack/EDIpack2py)
-* [TRIQS >= 3.2.0](https://github.com/TRIQS/triqs)
+* [TRIQS >= 4.0.0](https://github.com/TRIQS/triqs)
 
 Installation
 ------------

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -4,6 +4,9 @@
 
 ## Version 1.1.0
 
+* Apply TRIQS 4.0 compatibility fixes. Starting from this version, TRIQS 3.x.y
+  is no longer supported.
+
 * Expose the value of EDIpack's compilation flag `CMPLX_NORMAL` via the class
   attribute `EDIpackSolver.normal_complex_enabled`.
 

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -3,8 +3,10 @@
 About edipack2triqs
 ===================
 
-This package has been written by Igor Krivenko with contributions from Lorenzo
-Crippa.
+This package has been written by Igor Krivenko with contributions from
+
+- Lorenzo Crippa
+- Nils Wentzell
 
 License
 -------

--- a/edipack2triqs/fit.py
+++ b/edipack2triqs/fit.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import numpy as np
 
-from triqs.gf import BlockGf, MeshImFreq
+from triqs.gfs import BlockGf, MeshImFreq
 
 from edipack2py import global_env as ed
 
@@ -129,19 +129,19 @@ def _chi2_fit_bath(self, g: BlockGf, f: Optional[BlockGf] = None):
 
     :param g: Normal component of the function to fit (either the hybridization
               function or the Weiss field).
-    :type g: triqs.gf.block_gf.BlockGf
+    :type g: triqs.gfs.block_gf.BlockGf
 
     :param f: Anomalous component of the function to fit (either the
               hybridization function or the Weiss field). Required iff the bath
               is superconducting.
-    :type g: triqs.gf.block_gf.BlockGf
+    :type g: triqs.gfs.block_gf.BlockGf
 
     :return: - A bath object that contains resulting parameters of the fit.
              - The normal component of the fitted function.
              - (*optional*) The anomalous component of the fitted function.
 
-    :rtype: tuple[Bath, triqs.gf.block_gf.BlockGf] or
-            tuple[Bath, triqs.gf.block_gf.BlockGf, triqs.gf.block_gf.BlockGf]
+    :rtype: tuple[Bath, triqs.gfs.block_gf.BlockGf] or
+            tuple[Bath, triqs.gfs.block_gf.BlockGf, triqs.gfs.block_gf.BlockGf]
     """
 
     if self.h_params.bath is None:

--- a/edipack2triqs/fit.py
+++ b/edipack2triqs/fit.py
@@ -219,7 +219,7 @@ def _chi2_fit_bath(self, g: BlockGf, f: Optional[BlockGf] = None):
     # Create fitted G0 or \Delta
     #
 
-    mesh = MeshImFreq(beta=ed.beta, S="Fermion", n_iw=ed.Lmats)
+    mesh = MeshImFreq(beta=ed.beta, statistic="Fermion", n_iw=ed.Lmats)
     z_vals = np.array([complex(z) for z in mesh])
     get_method = ed.get_g0and if (self.config["CG_SCHEME"] == "weiss") \
         else ed.get_delta

--- a/edipack2triqs/solver.py
+++ b/edipack2triqs/solver.py
@@ -974,7 +974,7 @@ class EDIpackSolver:
             mesh = MeshReFreq(window=(ed.wini, ed.wfin), n_w=ed.Lreal)
             z_vals = np.asarray([complex(z) + ed.eps * 1j for z in mesh])
         else:
-            mesh = MeshImFreq(beta=ed.beta, S="Fermion", n_iw=ed.Lmats)
+            mesh = MeshImFreq(beta=ed.beta, statistic="Fermion", n_iw=ed.Lmats)
             z_vals = np.asarray([complex(z) for z in mesh])
 
         with chdircontext(self.wdname):
@@ -1136,13 +1136,17 @@ class EDIpackSolver:
 
         match axis:
             case "m":
-                mesh = MeshImFreq(beta=ed.beta, S="Boson", n_iw=ed.Lmats)
+                mesh = MeshImFreq(beta=ed.beta,
+                                  statistic="Boson",
+                                  n_iw=ed.Lmats)
                 z_vals = np.asarray([complex(z) for z in mesh])
             case "r":
                 mesh = MeshReFreq(window=(ed.wini, ed.wfin), n_w=ed.Lreal)
                 z_vals = np.asarray([complex(z) + ed.eps * 1j for z in mesh])
             case "t":
-                mesh = MeshImTime(beta=ed.beta, S="Boson", n_tau=ed.Ltau)
+                mesh = MeshImTime(beta=ed.beta,
+                                  statistic="Boson",
+                                  n_tau=ed.Ltau)
                 z_vals = np.asarray([complex(z) for z in mesh])
             case _:
                 raise AssertionError("Unexpected axis")
@@ -1171,7 +1175,7 @@ class EDIpackSolver:
         if self.phonon is None:
             return None
 
-        mesh = MeshImFreq(beta=ed.beta, S="Boson", n_iw=ed.Lmats)
+        mesh = MeshImFreq(beta=ed.beta, statistic="Boson", n_iw=ed.Lmats)
         z_vals = np.asarray([complex(z) for z in mesh])
 
         with chdircontext(self.wdname):

--- a/edipack2triqs/solver.py
+++ b/edipack2triqs/solver.py
@@ -17,7 +17,7 @@ import numpy as np
 from mpi4py import MPI
 
 import triqs.operators as op
-from triqs.gf import BlockGf, Gf, MeshImFreq, MeshReFreq, MeshImTime
+from triqs.gfs import BlockGf, Gf, MeshImFreq, MeshReFreq, MeshImTime
 
 from edipack2py import global_env as ed
 
@@ -203,7 +203,7 @@ class EDIpackSolver:
         the many-body operator ``c_dag(b, i)``. ``b`` and ``i`` are a (string or
         integer) block index and an index within a block respectively, which
         are used to construct output :py:class:`Green's function
-        containers <triqs.gf.block_gf.BlockGf>`.
+        containers <triqs.gfs.block_gf.BlockGf>`.
 
         :param hamiltonian: Many-body electronic Hamiltonian to diagonalize.
             Symmetries of this Hamiltonian are automatically analyzed and

--- a/example/attractive_hubbard_model.py
+++ b/example/attractive_hubbard_model.py
@@ -8,9 +8,9 @@ from itertools import product
 import numpy as np
 
 # TRIQS modules
-from triqs.gf import (Gf, BlockGf, MeshImFreq, MeshProduct,
-                      iOmega_n, conjugate, inverse)
-from triqs.gf.tools import dyson
+from triqs.gfs import (Gf, BlockGf, MeshImFreq, MeshProduct,
+                       iOmega_n, conjugate, inverse)
+from triqs.gfs.tools import dyson
 from triqs.operators import c, c_dag, n, dagger
 from triqs.lattice.tight_binding import TBLattice
 from h5 import HDFArchive

--- a/tests/test_fit_bath.py
+++ b/tests/test_fit_bath.py
@@ -112,7 +112,7 @@ class TestFitBath(unittest.TestCase):
         self.assertEqual(solver.h_params.ed_mode, EDMode.NORMAL)
         self.assertEqual(solver.nspin, 1)
 
-        mesh = MeshImFreq(beta=50.0, S="Fermion", n_iw=200)
+        mesh = MeshImFreq(beta=50.0, statistic="Fermion", n_iw=200)
         Delta = BlockGf(gf_struct=[("up", self.norb), ("dn", self.norb)],
                         mesh=mesh)
         G0 = BlockGf(gf_struct=[("up", self.norb), ("dn", self.norb)],
@@ -150,7 +150,7 @@ class TestFitBath(unittest.TestCase):
         self.assertEqual(solver.h_params.ed_mode, EDMode.NORMAL)
         self.assertEqual(solver.nspin, 2)
 
-        mesh = MeshImFreq(beta=50.0, S="Fermion", n_iw=200)
+        mesh = MeshImFreq(beta=50.0, statistic="Fermion", n_iw=200)
         Delta = BlockGf(gf_struct=[("up", self.norb), ("dn", self.norb)],
                         mesh=mesh)
         G0 = BlockGf(gf_struct=[("up", self.norb), ("dn", self.norb)],
@@ -188,7 +188,7 @@ class TestFitBath(unittest.TestCase):
                                verbose=3)
         self.assertEqual(solver.h_params.ed_mode, EDMode.NONSU2)
 
-        mesh = MeshImFreq(beta=50.0, S="Fermion", n_iw=200)
+        mesh = MeshImFreq(beta=50.0, statistic="Fermion", n_iw=200)
         Delta = BlockGf(gf_struct=[("up_dn", 2 * self.norb)], mesh=mesh)
         G0 = BlockGf(gf_struct=[("up_dn", 2 * self.norb)], mesh=mesh)
         d1 = inverse(iOmega_n + 0.4) + inverse(iOmega_n - 1.4)
@@ -236,7 +236,7 @@ class TestFitBath(unittest.TestCase):
                                verbose=0)
         self.assertEqual(solver.h_params.ed_mode, EDMode.SUPERC)
 
-        mesh = MeshImFreq(beta=50.0, S="Fermion", n_iw=200)
+        mesh = MeshImFreq(beta=50.0, statistic="Fermion", n_iw=200)
         Delta = BlockGf(gf_struct=[("up", norb), ("dn", norb)], mesh=mesh)
         Delta_an = BlockGf(gf_struct=[("up_dn", norb)], mesh=mesh)
 

--- a/tests/test_fit_bath.py
+++ b/tests/test_fit_bath.py
@@ -6,9 +6,9 @@ import numpy as np
 from numpy import multiply as mul
 
 import triqs.operators as op
-from triqs.gf import Gf, BlockGf, MeshImFreq, conjugate, transpose
-from triqs.gf.descriptors import SemiCircular, iOmega_n
-from triqs.gf.tools import inverse
+from triqs.gfs import Gf, BlockGf, MeshImFreq, conjugate, transpose
+from triqs.gfs.descriptors import SemiCircular, iOmega_n
+from triqs.gfs.tools import inverse
 from triqs.utility.comparison_tests import assert_block_gfs_are_close
 
 from edipack2triqs import EDMode

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -981,7 +981,7 @@ class TestSolver(unittest.TestCase):
         # Matsubara
         if zerotemp:
             return
-        D0_iw = Gf(mesh=MeshImFreq(beta=beta, S="Boson", n_iw=n_iw),
+        D0_iw = Gf(mesh=MeshImFreq(beta=beta, statistic="Boson", n_iw=n_iw),
                    target_shape=())
 
         chi_iw = D0_iw.copy()

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -7,15 +7,15 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 import triqs.operators as op
-from triqs.gf import (BlockGf,
-                      Gf,
-                      MeshReFreq,
-                      MeshImFreq,
-                      MeshImTime,
-                      conjugate,
-                      transpose)
-from triqs.gf.descriptors import Omega, iOmega_n
-from triqs.gf.tools import inverse, dyson
+from triqs.gfs import (BlockGf,
+                       Gf,
+                       MeshReFreq,
+                       MeshImFreq,
+                       MeshImTime,
+                       conjugate,
+                       transpose)
+from triqs.gfs.descriptors import Omega, iOmega_n
+from triqs.gfs.tools import inverse, dyson
 from triqs.utility.comparison_tests import (assert_gfs_are_close,
                                             assert_block_gfs_are_close)
 


### PR DESCRIPTION
## Summary

Ports edipack2triqs to the [TRIQS 4.0](https://github.com/TRIQS/triqs) release.

- Rename all `triqs.gf` imports to `triqs.gfs` (the module was renamed in TRIQS 4.0), and re-align the affected multi-line import continuation lines.
- CI now builds the TRIQS `4.0.x` branch (was `3.3.x`).
- Bump the documented minimum TRIQS requirement to `>= 4.0.0`.

## Testing

Full test suite passes against TRIQS 4.0.0 with EDIpack/edipack2py 6.1.0:

```
78 passed, 2 skipped
```

(The 2 skipped tests are the `_complex` general-bath cases, which run in CI under `-DCMPLX_NORMAL=ON`.)

`flake8 edipack2triqs/ tests/` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)